### PR TITLE
[WIP] open api 3 spec dynamic generation 

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,0 +1,20 @@
+<?php
+use Cake\Routing\RouteBuilder;
+use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
+
+Router::plugin(
+    'BEdita/DevTools',
+    [
+        'path' => '/tools',
+    ],
+    function (RouteBuilder $routes) {
+        // OpenAPI 3 spec in YAML format.
+        $routes->connect(
+            '/open-api',
+            ['controller' => 'Tools', 'action' => 'openApi', 'method' => 'GET']
+        );
+
+        $routes->fallbacks(DashedRoute::class);
+    }
+);

--- a/src/Controller/ToolsController.php
+++ b/src/Controller/ToolsController.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\DevTools\Controller;
+
+use BEdita\API\Controller\AppController as BaseController;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\Event\Event;
+use Cake\Routing\Router;
+
+/**
+ * Controller endpoint for `/tools` endpoint
+ */
+class ToolsController extends BaseController
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('defaultAuthorized', true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFilter(Event $event)
+    {
+    }
+
+    /**
+     * Give suggestions for localities.
+     *
+     * @return void
+     */
+    public function openApi()
+    {
+        $this->request->allowMethod('get');
+        $this->prepareSpec();
+    }
+
+    /**
+     * Prepare OpenAPI v3 Yaml specification file content.
+     *
+     * @return void
+     */
+    protected function prepareSpec()
+    {
+        $this->set('project', Configure::read('Project.name'));
+        $this->set('url', Router::fullBaseUrl());
+
+        $this->viewBuilder()
+            ->setPlugin('BEdita/DevTools')
+            ->setLayout('open_api')
+            ->setTemplatePath('OpenAPI')
+            ->setTemplate('yaml');
+            //->setClassName('View');
+    }
+}

--- a/src/Middleware/HtmlMiddleware.php
+++ b/src/Middleware/HtmlMiddleware.php
@@ -38,7 +38,8 @@ class HtmlMiddleware
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        if (!($request instanceof ServerRequest) || !$request->is('html')) {
+        $paths = explode('/', $request->url);
+        if (!($request instanceof ServerRequest) || !$request->is('html') || $paths[0] === 'tools') {
             // Not an HTML request, or unable to detect easily.
             return $next($request, $response);
         }

--- a/src/Template/Element/OpenAPI/paths.ctp
+++ b/src/Template/Element/OpenAPI/paths.ctp
@@ -1,0 +1,19 @@
+paths:
+  /status:
+      summary: API Status
+      description: Service status response
+      security:
+        - apikey: []
+      responses:
+        '200':
+          description:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+      default:
+        description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"

--- a/src/Template/Element/OpenAPI/schemas.ctp
+++ b/src/Template/Element/OpenAPI/schemas.ctp
@@ -1,0 +1,34 @@
+  schemas:
+
+    Links:
+      properties:
+        self:
+          type: string
+        home:
+          type: string
+
+    Status:
+      properties:
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          properties:
+            status:
+              properties:
+                environment:
+                  type: string
+
+    Error:
+      properties:
+        error:
+          properties:
+            status:
+              type: string
+            title:
+              type: string
+            code:
+              type: string
+            description:
+              type: string
+          links:
+            $ref: '#/components/schemas/Links'

--- a/src/Template/Layout/open_api.ctp
+++ b/src/Template/Layout/open_api.ctp
@@ -1,0 +1,1 @@
+<?= $this->fetch('content') ?>

--- a/src/Template/OpenAPI/yaml.ctp
+++ b/src/Template/OpenAPI/yaml.ctp
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: <?= $project ?> API
+  description: Build great apps with BE4
+  version: "1.0.0"
+
+servers:
+  - url: <?= $url ?>
+
+<?= $this->element('OpenAPI/paths') ?>
+
+components:
+  securitySchemes:
+    apikey:
+      type: apiKey
+      name: server_token
+      in: query
+
+<?= $this->element('OpenAPI/schemas') ?>


### PR DESCRIPTION
URL to create dynamic spec is: `/tools/open-api`

Output format: **yaml**

Problems: invoking URL from a browser or in general with an `html` accept header we need to disable current HTML middleware in order to get an `in browser` response. 

I did a brutal check in `HtmlMiddleware` to be improved.

Otherwise we get a missing template error: request type is forced to `jsonapi` and template is loaded in a missing `jsonapi` folder
