### PR TITLE
Avoid DebugKit load - enable HTML render without

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
+  - 7.2
 
 cache:
   directories:
@@ -18,15 +16,7 @@ jobs:
   fast_finish: true
 
   include:
-    - php: 5.6
-      env: "PREFER_LOWEST=1"
-      install:
-        - composer install --prefer-dist --no-interaction
-        - composer update --prefer-dist --prefer-lowest --no-interaction
-        # Ensure PHPUnit is installed from source (i.e.: Git repository) otherwise a wrong version is being detected. :|
-        - rm -rf vendor/phpunit/phpunit vendor/bin/phpunit && COMPOSER_CACHE_DIR=/dev/null composer update --prefer-source --prefer-lowest --no-interaction
-
-    - php: 7.0
+    - php: 7.2
       env: "RUN=phpcs"
       before_script: skip
       script: |
@@ -35,7 +25,7 @@ jobs:
           ./config ./src ./tests
       after_success: ~
 
-    - php: 7.1
+    - php: 7.2
       env: "RUN=phpstan"
       install:
         - composer install --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": ">=3.4.4, <4.0",
+        "php": ">=7.1.0",
+        "cakephp/cakephp": "~3.5.3",
         "cakephp/debug_kit": "~3.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
-        "cakephp/cakephp-codesniffer": "~3.0",
-        "phpmd/phpmd": "*"
+        "phpunit/phpunit": "^6",
+        "cakephp/cakephp-codesniffer": "~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "cakephp-plugin",
     "description": "A plugin to give some useful tools to BEdita developers.",
     "keywords": ["cakephp", "cake3", "plugin", "bedita", "debug_kit", "travis", "scrutinizer"],
-    "license": "LGPL",
+    "license": "LGPL-3.0-or-later",
     "support": {
         "source": "https://github.com/bedita/dev-tools",
         "issues": "https://github.com/bedita/dev-tools/issues"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,7 @@ ServerRequest::addDetector('html', ['accept' => ['text/html', 'application/xhtml
 
 if (empty(Configure::read('Plugins.DebugKit')) || !Configure::read('debug')) {
     /**
-     * Place HTML rendering middleware on top of middleware queue.
+     * Place HTML rendering middleware on top of middleware queue and retturn
      */
     EventManager::instance()->on('Server.buildMiddleware', function (Event $event, MiddlewareQueue $middlewareQueue) {
             $middlewareQueue->prepend(new HtmlMiddleware());

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,6 +17,7 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
+use Cake\Core\Plugin;
 
 ServerRequest::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
 
@@ -37,6 +38,10 @@ if (empty(Configure::read('Plugins.DebugKit')) || !Configure::read('debug')) {
 $panels = ['BEdita/DevTools.Configuration'];
 $panels = array_merge(Configure::read('DebugKit.panels') ?: [], $panels);
 Configure::write('DebugKit.panels', $panels);
+
+if (Configure::read('Plugins.DebugKit') && Configure::read('debug') && !Plugin::loaded('DebugKit')) {
+    Plugin::load('DebugKit');
+}
 
 /**
  * Place HTML rendering middleware after `DebugKitMiddleware`.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,7 +17,6 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
-use Cake\Core\Plugin;
 
 ServerRequest::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
 
@@ -38,10 +37,6 @@ if (empty(Configure::read('Plugins.DebugKit')) || !Configure::read('debug')) {
 $panels = ['BEdita/DevTools.Configuration'];
 $panels = array_merge(Configure::read('DebugKit.panels') ?: [], $panels);
 Configure::write('DebugKit.panels', $panels);
-
-if (Configure::read('Plugins.DebugKit') && Configure::read('debug') && !Plugin::loaded('DebugKit')) {
-    Plugin::load('DebugKit');
-}
 
 /**
  * Place HTML rendering middleware after `DebugKitMiddleware`.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,12 +13,23 @@
 
 use BEdita\DevTools\Middleware\HtmlMiddleware;
 use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
-use DebugKit\Middleware\DebugKitMiddleware;
+
+ServerRequest::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
+
+if (empty(Configure::read('Plugins.DebugKit')) || !Configure::read('debug')) {
+    /**
+     * Place HTML rendering middleware on top of middleware queue.
+     */
+    EventManager::instance()->on('Server.buildMiddleware', function (Event $event, MiddlewareQueue $middlewareQueue) {
+            $middlewareQueue->prepend(new HtmlMiddleware());
+    });
+
+    return;
+}
 
 /**
  * Configure DebugKit panels.
@@ -27,14 +38,9 @@ $panels = ['BEdita/DevTools.Configuration'];
 $panels = array_merge(Configure::read('DebugKit.panels') ?: [], $panels);
 Configure::write('DebugKit.panels', $panels);
 
-if (!Plugin::loaded('DebugKit')) {
-    Plugin::load('DebugKit', ['bootstrap' => true, 'routes' => true]);
-}
-
 /**
- * Place HTML rendering middleware on top of middleware queue.
+ * Place HTML rendering middleware after `DebugKitMiddleware`.
  */
-ServerRequest::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
 EventManager::instance()->on('Server.buildMiddleware', function (Event $event, MiddlewareQueue $middlewareQueue) {
-    $middlewareQueue->insertAfter(DebugKitMiddleware::class, new HtmlMiddleware());
+    $middlewareQueue->insertAfter('DebugKit\Middleware\DebugKitMiddleware', new HtmlMiddleware());
 });


### PR DESCRIPTION
In this PR:

* avoid use of deprecated `Plugin::load` -> `DebugKit` loaded in main app only if configured in `Plugins`
* `Html` middleware can be enabled also without `DebugKit` 
* CI updates