### PR TITLE
Travis update to Bionic + PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
-dist: trusty
+dist: bionic
 sudo: false
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 cache:
   directories:

--- a/src/Middleware/HtmlMiddleware.php
+++ b/src/Middleware/HtmlMiddleware.php
@@ -25,7 +25,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class HtmlMiddleware
 {
-
     use ViewVarsTrait;
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,26 +48,26 @@ Configure::write('App', [
     'encoding' => 'utf-8',
     'paths' => [
         'plugins' => [ROOT . 'Plugin' . DS],
-        'templates' => [APP . 'Template' . DS]
-    ]
+        'templates' => [APP . 'Template' . DS],
+    ],
 ]);
 
 Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
-        'serialize' => true
+        'serialize' => true,
     ],
     '_cake_model_' => [
         'engine' => 'File',
         'prefix' => 'cake_model_',
-        'serialize' => true
+        'serialize' => true,
     ],
     'default' => [
         'engine' => 'File',
         'prefix' => 'default_',
-        'serialize' => true
-    ]
+        'serialize' => true,
+    ],
 ]);
 
 // Ensure default test connection is defined


### PR DESCRIPTION
This PR updates Travis CI tasks

* `bionic` instead of `trusty` as OS
* PHP 7.4 added, 7.1 dropped
