### PR TITLE
update scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,3 +11,5 @@ filter:
     - 'webroot/*'
   dependency_paths:
     - 'vendors/*'
+    - 'webroot/js/jquery.min.js'
+    - 'webroot/js/jquery.jsonview.js'


### PR DESCRIPTION
treat jquery files as dependencies, excluded from analysis