### PR TITLE
Add phpstan/phpstan 1.5 + fix php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
+      - 'composer.json'
   push:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
+      - 'composer.json'
 
 jobs:
   cs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -70,7 +70,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v1, phpstan'
+          tools: 'composer:v1'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress --error-format=github
 
   unit:
     name: 'Run unit tests'

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /vendor
 composer.lock
 phinx.yml
+/phpstan.neon
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "cakephp/bake": "^1.12",
         "cakephp/migrations": "^2.4.2",
         "cakephp/cakephp-codesniffer": "~3.2.1",
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^6.5"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 0


### PR DESCRIPTION
This updates `php` workflow, so that `phpstan` dependency version is used (instead of downloading it with composer, during CI).

This activity in bedita started with https://github.com/bedita/bedita/pull/1889