### PR TITLE
feat: filter items by milestone

### DIFF
--- a/src/Command/ChangeLogCommand.php
+++ b/src/Command/ChangeLogCommand.php
@@ -121,8 +121,8 @@ class ChangeLogCommand extends Command
     /**
      * Filter items by Milestone: major version of item mileston should match requested version (4 o 5 for instance).
      *
-     * @param array $items
-     * @param string $version
+     * @param array $items Changelog items
+     * @param string $version Release version
      * @return array
      */
     protected function filterItems(array $items, string $version): array

--- a/src/Command/ChangeLogCommand.php
+++ b/src/Command/ChangeLogCommand.php
@@ -132,7 +132,8 @@ class ChangeLogCommand extends Command
         return array_filter(
             $items,
             function ($item) use ($major) {
-                $milestone = (string)Hash::get($item, 'milestone.title');
+                /** @var string $milestone */
+                $milestone = Hash::get($item, 'milestone.title');
                 $milestone = str_replace('-', '.', $milestone);
                 $v = substr($milestone, 0, (int)strpos($milestone, '.'));
 

--- a/src/Command/ChangeLogCommand.php
+++ b/src/Command/ChangeLogCommand.php
@@ -106,14 +106,39 @@ class ChangeLogCommand extends Command
 
         $json = $this->fetchPrs((string)$from);
         $items = (array)Hash::get($json, 'items');
+        $version = (string)$args->getArgument('version');
+        $items = $this->filterItems($items, $version);
         $io->out(sprintf('Loaded %d prs', count($items)));
 
         $changeLog = $this->createChangeLog($items);
-        $this->saveChangeLog($changeLog, (string)$args->getArgument('version'));
+        $this->saveChangeLog($changeLog, $version);
 
         $io->out('Changelog created. Bye.');
 
         return null;
+    }
+
+    /**
+     * Filter items by Milestone: major version of item mileston should match requested version (4 o 5 for instance).
+     *
+     * @param array $items
+     * @param string $version
+     * @return array
+     */
+    protected function filterItems(array $items, string $version): array
+    {
+        $major = substr($version, 0, (int)strpos($version, '.'));
+
+        return array_filter(
+            $items,
+            function ($item) use ($major) {
+                $milestone = (string)Hash::get($item, 'milestone.title');
+                $milestone = str_replace('-', '.', $milestone);
+                $v = substr($milestone, 0, (int)strpos($milestone, '.'));
+
+                return $v == $major;
+            }
+        );
     }
 
     /**
@@ -148,10 +173,6 @@ class ChangeLogCommand extends Command
     {
         $res = [];
         foreach ($items as $item) {
-            $milestone = Hash::get($item, 'milestone.title');
-            if (is_string($milestone) && substr($milestone, 0, 1) !== '4') {
-                continue;
-            }
             $labels = Hash::extract($item, 'labels.{n}.name');
             $type = $this->classify((array)$labels);
             $res[$type][] = $item;

--- a/tests/TestCase/Command/ChangeLogCommandTest.php
+++ b/tests/TestCase/Command/ChangeLogCommandTest.php
@@ -65,6 +65,7 @@ class ChangeLogCommandTest extends TestCase
      * @covers ::classify()
      * @covers ::createChangeLog()
      * @covers ::saveChangeLog()
+     * @covers ::filterItems()
      * @covers ::loglines()
      */
     public function testExecute(): void


### PR DESCRIPTION
This PR adds a filter by milestone in changelog extraction: only matching major version milestones will be considered. 
For instance: if version is `4.#.#` only pull requests having milestone `4-*` or `4.*` will be included.
 