### PR TITLE
fix: use MiddlewareInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "@test",
             "@cs-check"
         ],
-        "analyze": "vendor/bin/phpstan analyse",
+        "stan": "vendor/bin/phpstan analyse",
         "cs-check": "vendor/bin/phpcs",
         "cs-fix": "vendor/bin/phpcbf",
         "test": "vendor/bin/phpunit --colors=always"

--- a/src/Middleware/HtmlMiddleware.php
+++ b/src/Middleware/HtmlMiddleware.php
@@ -18,36 +18,33 @@ use Cake\Http\ServerRequest;
 use Cake\View\ViewVarsTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Intercept HTML requests and render an user-friendly view.
  *
  * @since 4.0.0
  */
-class HtmlMiddleware
+class HtmlMiddleware implements MiddlewareInterface
 {
     use ViewVarsTrait;
 
     /**
-     * Render HTML requests using a user-friendly template.
-     *
-     * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
-     * @param \Psr\Http\Message\ResponseInterface $response Response object.
-     * @param callable $next Next middleware in queue.
-     * @return \Psr\Http\Message\ResponseInterface
+     * @inheritDoc
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (!($request instanceof ServerRequest) || !$request->is('html')) {
             // Not an HTML request, or unable to detect easily.
-            return $next($request, $response);
+            return $handler->handle($request);
         }
 
         // Set correct "Accept" header, and proceed as usual.
         $request = $request->withHeader('Accept', 'application/vnd.api+json');
 
         /** @var \Cake\Http\Response $response */
-        $response = $next($request, $response);
+        $response = $handler->handle($request);
 
         if (!in_array($response->getHeaderLine('Content-Type'), ['application/json', 'application/vnd.api+json'])) {
             // Not a JSON response.

--- a/tests/TestCase/Command/ChangeLogCommandTest.php
+++ b/tests/TestCase/Command/ChangeLogCommandTest.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Test\TestCase\Command;
 
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Response;
 use Cake\Routing\Router;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**


### PR DESCRIPTION
New `MiddlewareInterface` for `HtmlMiddleware` - “Double pass” middlewares are now deprecated from CakePHP v4.3
