### PR TITLE
Move HtmlMiddleware and skip authorization check for DebugKit

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -43,6 +43,7 @@ class Plugin extends BasePlugin
         $panels = ['BEdita/DevTools.Configuration'];
         $panels = array_merge((array)Configure::read('DebugKit.panels', []), $panels);
         Configure::write('DebugKit.panels', $panels);
+        Configure::write('DebugKit.ignoreAuthorization', true);
     }
 
     /**
@@ -55,6 +56,8 @@ class Plugin extends BasePlugin
             return $middleware;
         }
 
-        return $middleware->prepend([new AssetMiddleware(), new HtmlMiddleware()]);
+        return $middleware
+            ->prepend(new AssetMiddleware())
+            ->add(new HtmlMiddleware());
     }
 }

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -90,7 +90,7 @@ class PluginTest extends TestCase
                 false,
             ],
             'true' => [
-                [AssetMiddleware::class, HtmlMiddleware::class, ErrorHandlerMiddleware::class],
+                [AssetMiddleware::class, ErrorHandlerMiddleware::class, HtmlMiddleware::class],
                 true,
             ],
             'null' => [


### PR DESCRIPTION
To work well with DebugKit the following actions are taken:
* add `HtmlMiddleware` at the end of the queue. It needs because `DebugKitMiddleware` should be applied before `HtmlMiddleware`
* the authorization check of `Authorization` plugin is ignored for `DebugKit`