### PR TITLE
Update php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1"]'
+      php_versions: '["7.4", "8.1", "8.2"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1"]'
+      php_versions: '["7.4", "8.1", "8.2"]'
 
   unit:
     name: 'Run unit tests'
@@ -30,11 +30,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4, 8.0, 8.1]
+        php-version: [7.4, 8.1, 8.2]
 
     steps:
       - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: 'Composer config GH token if available'
         run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
@@ -48,10 +48,10 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v2'
+        uses: 'actions/cache@v3'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
           key: "composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}"
@@ -72,13 +72,13 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
+        uses: 'codecov/codecov-action@v3'
         with:
-          file: './clover.xml'
+          files: './clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,3 +13,18 @@ filter:
     - 'vendors/*'
     - 'webroot/js/jquery.min.js'
     - 'webroot/js/jquery.jsonview.js'
+
+build:
+  image: default-jammy
+  environment:
+    node: v18
+  nodes:
+    analysis:
+      environment:
+        php:
+          version: 8.2
+          pecl_extensions:
+            - zip
+      tests:
+        override:
+          - php-scrutinizer-run


### PR DESCRIPTION
This fixes some deprecations in php github workflow, by updating the following:

 - actions/checkout@v3
 - actions/cache@v3
 - actions/upload-artifact@v3
 - codecov/codecov-action@v3

Furthermore set-output is replaced with GITHUB_OUTPUT 

Bonuses:

 - php versions 7.4, 8.1 and 8.2 (instead of 7.4, 8.0 and 8.1)
 - scrutinizer config update: use php 8.2