### PR TITLE
Cakephp 4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "cakephp/cakephp": "^4.3.0",
+        "cakephp/cakephp": "^4.4",
         "cakephp/debug_kit": "^4.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "cakephp/cakephp": "^4.4",
+        "cakephp/cakephp": "^4.4.0",
         "cakephp/debug_kit": "^4.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
     "require-dev": {
         "cakephp/bake": "^2.6",
         "cakephp/migrations": "^3.4.0",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
-        "phpstan/phpstan": "^1.5",
-        "phpunit/phpunit": "^9.0"
+        "cakephp/cakephp-codesniffer": "~4.7.0",
+        "phpstan/phpstan": "^1.8.2",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "cakephp/cakephp": "^4.4.0",
+        "cakephp/cakephp": "^4.5.0",
         "cakephp/debug_kit": "^4.7"
     },
     "require-dev": {


### PR DESCRIPTION
This updates composer dependency for cakephp to version 4.5

Note: `cd <cakephp-upgrade-path>; bin/cake upgrade rector --rules cakephp44 <dev-tools-path>/src`, no change applied.