### PR TITLE
Fix position of HTML middleware

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,7 +57,7 @@ class Plugin extends BasePlugin
         }
 
         return $middleware
-            ->prepend(new AssetMiddleware())
-            ->add(new HtmlMiddleware());
+            ->prepend(new HtmlMiddleware())
+            ->prepend(new AssetMiddleware());
     }
 }

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -89,7 +89,7 @@ class PluginTest extends TestCase
                 false,
             ],
             'true' => [
-                [AssetMiddleware::class, ErrorHandlerMiddleware::class, HtmlMiddleware::class],
+                [AssetMiddleware::class, HtmlMiddleware::class, ErrorHandlerMiddleware::class],
                 true,
             ],
             'null' => [


### PR DESCRIPTION
This PR fixes the position of `HtmlMiddleware` to show all errors as HTML using Cake 5.